### PR TITLE
feat: Replace external data source with an implementation based on terraform functions

### DIFF
--- a/infrastructure/kubernetes-resources/99-ouputs.tf
+++ b/infrastructure/kubernetes-resources/99-ouputs.tf
@@ -4,5 +4,5 @@
 ##############################################################################
 
 output "sha256sum_qweb" {
-  value = data.external.sha256sum_charts_qweb.result
+  value = local.sha256sum_charts_qweb
 }

--- a/utils/sha256sum-dir-content.py
+++ b/utils/sha256sum-dir-content.py
@@ -1,7 +1,7 @@
 """
 Calculate the SHA256 hash for the content of each file in the target directory
 
-This is used to get a json dict to be used with the terraform external data source/
+This cab be used as an external data source in terraform or to validate a the hash map generated in terraform.
 
 See: https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external
 
@@ -9,17 +9,17 @@ e.g.:
 command: python3 sha256sum-dir-content.py --directory charts/qweb --output json --pretty-print
 output:
 {
-  "bb987e6a8ef45a99255d1d632812482d5f0f3255ea841520b4d90342df5fe2b3": "charts/qweb/.helmignore",
-  "e9777e62e15a789d3c1da0c7a3ddf6aca1956ed299a3a9cec5f70a94859a9b21": "charts/qweb/values.yaml",
-  "6f21a55170a6115ea5fe1fc0f321cd6009e9b9b84e684d4af09a32670bb4bfd0": "charts/qweb/Chart.yaml",
-  "1f926a02e9bede5bcb8d58043c5f0882cc1b672badf49a73d83fa8389ca9267a": "charts/qweb/templates/service.yaml",
-  "2372f31a93af5aa21109d85510f45e84850b0eac6e1fc78352dc0a3bf75c4ed7": "charts/qweb/templates/deployment.yaml",
-  "766882bd949af6bd435ebe5df9f4c9e27a3bee4f6056159e8068fb61909ff732": "charts/qweb/templates/NOTES.txt",
-  "9940d78c8f6f858a0b490fb710696f9b7e66a08657fc32f2b04257bd0dd9542d": "charts/qweb/templates/hpa.yaml",
-  "2688532ed0028fd24ace90463362919b84bc484da386cbc0e0bbf96963dd6caf": "charts/qweb/templates/ingress.yaml",
-  "fac50e17356defbb63a3c23a88bea77dafa211672b69ed2e3df31aa8ae901104": "charts/qweb/templates/_helpers.tpl",
-  "57133898aa02f488644b19e0af51ae8106af59fd213f34a54d1a6df3f861e672": "charts/qweb/templates/serviceaccount.yaml",
-  "94574e1c7bd6c129c83df7c44240b120bd1aa6436076fd39b2b8d9a7dcf1b0b7": "charts/qweb/templates/tests/test-connection.yaml"
+  "bb987e6a8ef45a99255d1d632812482d5f0f3255ea841520b4d90342df5fe2b3": ".helmignore",
+  "e9777e62e15a789d3c1da0c7a3ddf6aca1956ed299a3a9cec5f70a94859a9b21": "values.yaml",
+  "6f21a55170a6115ea5fe1fc0f321cd6009e9b9b84e684d4af09a32670bb4bfd0": "Chart.yaml",
+  "1f926a02e9bede5bcb8d58043c5f0882cc1b672badf49a73d83fa8389ca9267a": "templates/service.yaml",
+  "2372f31a93af5aa21109d85510f45e84850b0eac6e1fc78352dc0a3bf75c4ed7": "templates/deployment.yaml",
+  "766882bd949af6bd435ebe5df9f4c9e27a3bee4f6056159e8068fb61909ff732": "templates/NOTES.txt",
+  "9940d78c8f6f858a0b490fb710696f9b7e66a08657fc32f2b04257bd0dd9542d": "templates/hpa.yaml",
+  "2688532ed0028fd24ace90463362919b84bc484da386cbc0e0bbf96963dd6caf": "templates/ingress.yaml",
+  "fac50e17356defbb63a3c23a88bea77dafa211672b69ed2e3df31aa8ae901104": "templates/_helpers.tpl",
+  "57133898aa02f488644b19e0af51ae8106af59fd213f34a54d1a6df3f861e672": "templates/serviceaccount.yaml",
+  "94574e1c7bd6c129c83df7c44240b120bd1aa6436076fd39b2b8d9a7dcf1b0b7": "templates/tests/test-connection.yaml"
 }
 
 """
@@ -41,7 +41,7 @@ def sha256sum_dir_content(directory: Path) -> dict[str, str]:
     for ppath in directory.rglob("*"):
         if ppath.is_file():
             content = ppath.read_bytes()
-            data[sha256(content).hexdigest()] = ppath.as_posix()
+            data[sha256(content).hexdigest()] = ppath.relative_to(directory).as_posix()
 
     return data
 


### PR DESCRIPTION
* Instead of relay on an external data source that use a python script, replace it with an implementation based on terraform functions.
* Only include the relative path in the output, to simplify the terraform implementation and improve the output reading. Modify the python script accordingly.